### PR TITLE
Removed reference to missing 'lookup' function in {reader,writer}.cljs

### DIFF
--- a/src/cljs/fressian_cljs/reader.cljs
+++ b/src/cljs/fressian_cljs/reader.cljs
@@ -1,7 +1,6 @@
 (ns fressian-cljs.reader
   (:use [fressian-cljs.defs :only [codes TaggedObject StructType]]
-        [fressian-cljs.fns :only [ read-utf8-chars expected lookup
-                                   byte-array-to-uuid]])
+        [fressian-cljs.fns :only [read-utf8-chars expected byte-array-to-uuid]])
   (:require [goog.string :as gstring]
             [goog.string.format]))
 

--- a/src/cljs/fressian_cljs/writer.cljs
+++ b/src/cljs/fressian_cljs/writer.cljs
@@ -1,8 +1,7 @@
 (ns fressian-cljs.writer
   (:use [fressian-cljs.defs :only [codes ranges tag-to-code TaggedObject
                                    old-index]]
-        [fressian-cljs.fns :only [read-utf8-chars expected lookup
-                                  buffer-string-chunk-utf8 uuid-to-byte-array]])
+        [fressian-cljs.fns :only [read-utf8-chars expected buffer-string-chunk-utf8 uuid-to-byte-array]])
   (:require [goog.string :as gstring]
             [goog.string.format]
             [fressian-cljs.adler32 :as adler32]))


### PR DESCRIPTION
Hi there - there was a reference hanging over to a `fressian-cljs.fns/lookup` function in both 'reader.cljs' and 'writer.cljs', which was causing james-henderson/chord#28.

Let me know if there's anything you need from me to get this merged :)

James