### PR TITLE
Add support for encoding ArrayBuffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 out
 repl
 pom.xml
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ target
 out
 repl
 pom.xml
+pom.xml.asc
 .idea

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,12 @@
   :url "https://github.com/JoelSanchez/fressian-cljs"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :repositories {"releases"
+                 {:url "https://repo.clojars.org"
+                  :creds :gpg}
+                 "snapshots"
+                 {:url "https://repo.clojars.org"
+                  :creds :gpg}}
   :cljsbuild
   { :builds 
     {:product

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject joelsanchez/fressian-cljs "0.2.0"
+(defproject joelsanchez/fressian-cljs "0.2.1"
   :dependencies [[org.clojure/clojurescript "1.7.122" :scope "provided"]]
   :plugins [[lein-cljsbuild "1.1.0"]
             [com.cemerick/clojurescript.test "0.3.3"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.unit8/fressian-cljs "0.2.0"
+(defproject joelsanchez/fressian-cljs "0.2.0"
   :dependencies [[org.clojure/clojurescript "1.7.122" :scope "provided"]]
   :plugins [[lein-cljsbuild "1.1.0"]
             [com.cemerick/clojurescript.test "0.3.3"]]

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,10 @@
   :plugins [[lein-cljsbuild "1.1.0"]
             [com.cemerick/clojurescript.test "0.3.3"]]
   :source-paths ["src/clj" "src/cljs"]
+  :description "Fork of kawasima/fressian-cljs with support for ArrayBuffers"
+  :url "https://github.com/JoelSanchez/fressian-cljs"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
   :cljsbuild
   { :builds 
     {:product

--- a/src/cljs/fressian_cljs/writer.cljs
+++ b/src/cljs/fressian_cljs/writer.cljs
@@ -274,6 +274,9 @@
   (write-tag wtr "inst" 1)
   (write-int wtr (.getTime d)))
 
+(defmethod internal-write js/ArrayBuffer [wtr d]
+  (write-bytes wtr (js/Uint8Array. d)))
+
 ;; Javascript Array
 (defmethod internal-write js/Array [wtr arr]
   (write-list wtr arr))


### PR DESCRIPTION
This allows users to upload files via Websockets using Fressian as transport format (jahoren/Chord).
```
(let [fr (js/FileReader.)
      file (-> some-js-event .-target .-files (aget 0))]
  (set! (.-onload fr) #(send-this-to-chord (-> fr .-result)))
  (.readAsArrayBuffer fr file))
```