### PR TITLE
Change *BASE* to BASE to fix "earmuffs" warning

### DIFF
--- a/src/cljs/fressian_cljs/adler32.cljs
+++ b/src/cljs/fressian_cljs/adler32.cljs
@@ -1,6 +1,6 @@
 (ns fressian-cljs.adler32)
 
-(def *BASE* 65521)
+(def BASE 65521)
 
 (defprotocol Adler32Protocol
   (update! [_ b] [_ bs off len])
@@ -13,8 +13,8 @@
           (let [s1 (+ (bit-and @value 0xffff) (bit-and b 0xff))
                 s2 (+ (bit-and (bit-shift-right @value 16) 0xffff) s1)]
             (reset! value
-                    (bit-or (bit-shift-left (mod s2 *BASE*) 16)
-                            (mod s1 *BASE*)))))
+                    (bit-or (bit-shift-left (mod s2 BASE) 16)
+                            (mod s1 BASE)))))
   (update! [_ bs off len]
           (doseq [i (range off (+ off len))]
             (update! _ (aget bs i))))


### PR DESCRIPTION
Hi, and thanks for creating the fressian-cljs library. I've made a trivial change to the library to fix a warning message that occurs during the shadow-cljs build process:

````
------ WARNING #1 - :non-dynamic-earmuffed-var ---------------------------------
Resource: fressian_cljs/adler32.cljs:3:1
*BASE* not declared dynamic and thus is not dynamically rebindable, but its name suggests otherwise. Please either indicate ^:dynamic *BASE* or change the name
````                     

Alternatively, `*BASE*` could be declared with `^:dynamic`.

I would appreciate it if you would merge this, and bump the version number, I guess, as right now this warning pops up every time we make a build. Thanks!